### PR TITLE
Restore Tracing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 serve:
-	go run main.go
+	GOOGLE_APPLICATION_CREDENTIALS=.github/service-account.json go run main.go
 .PHONY:=serve
 
 format:

--- a/main.go
+++ b/main.go
@@ -57,6 +57,13 @@ func main() {
 	tracer := func(w http.ResponseWriter, r *http.Request) {
 		ctx, span := trace.StartSpan(r.Context(), r.Method+" "+r.URL.Path)
 		defer span.End()
+		attrs := []trace.Attribute{
+			trace.StringAttribute("URL", r.URL.String()),
+		}
+		for key := range r.Header {
+			attrs = append(attrs, trace.StringAttribute(key, r.Header.Get(key)))
+		}
+		span.AddAttributes(attrs...)
 		http.DefaultServeMux.ServeHTTP(w, r.WithContext(ctx))
 	}
 


### PR DESCRIPTION
Without an appengine sdk, you have to add your own parent span to all http requests for the tracing system to pass them through.

~~Still missing the parent span when going through google servers tho.~~ *fixed*

![example](https://user-images.githubusercontent.com/1416308/75105034-e9f89980-55d5-11ea-8374-08e3e11f3bc1.png)