### PR TITLE
removing codecov token

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,8 +26,6 @@ jobs:
 
     - name: Codecov
       uses: codecov/codecov-action@v1.0.5
-      with:
-        token: "5c59aefa-2f68-41fe-b438-8c0ec2918830"
 
     - name: Build
       run: go build -v .

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,6 +26,8 @@ jobs:
 
     - name: Codecov
       uses: codecov/codecov-action@v1.0.5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Build
       run: go build -v .

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -8,9 +8,12 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@master
         with:
+          project_id: crucial-alpha-706
           service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
       - name: Deploy to staging
         id: deploy
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,8 +12,6 @@ jobs:
           project_id: crucial-alpha-706
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
-      - name: Use gcloud CLI
-        run: gcloud info
       - name: Deploy to staging
         id: deploy
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,6 +12,8 @@ jobs:
           project_id: crucial-alpha-706
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
+      - name: Use gcloud CLI
+        run: gcloud info
       - name: Deploy to staging
         id: deploy
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,10 +6,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@master
         with:
+          project_id: crucial-alpha-706
           service_account_key: ${{ secrets.GCP_SA_KEY }}
-
+          export_default_credentials: true
       - name: Deploy to staging
         id: deploy
         env:


### PR DESCRIPTION
According to the [Codecov action documentation](https://github.com/codecov/codecov-action), a token is not required for public repositories.

I have regenerated the existing token in case there are some other attack vectors I am not aware of.

Resolved #18 