### PR TITLE
Lazy Image Loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 serve:
-	GOOGLE_APPLICATION_CREDENTIALS=.github/service-account.json go run main.go
+	GOOGLE_APPLICATION_CREDENTIALS=.github/service-account.json \
+	GOOGLE_CLOUD_PROJECT=crucial-alpha-706 \
+	go run main.go
 .PHONY:=serve
 
 format:

--- a/appengine/appengine.go
+++ b/appengine/appengine.go
@@ -11,15 +11,17 @@ import (
 	"go.opencensus.io/trace"
 )
 
-func AppID(context.Context) string {
-	return "crucial-alpha-706"
+func ProjectID() string {
+	// Note: there is also a metadata API service where other info is available
+	// https://pkg.go.dev/cloud.google.com/go@v0.84.0/compute/metadata#ProjectID
+	return os.Getenv(`GOOGLE_CLOUD_PROJECT`)
 }
 
 func Main() {
 
 	// Create and register a OpenCensus Stackdriver Trace exporter.
 	exporter, err := stackdriver.NewExporter(stackdriver.Options{
-		ProjectID: AppID(context.TODO()),
+		ProjectID: ProjectID(),
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/cron/cron.go
+++ b/cron/cron.go
@@ -182,7 +182,7 @@ func (x *feedParser) enqueueBatch(ids []int) error {
 				AppEngineHttpRequest: &taskspb.AppEngineHttpRequest{
 					HttpMethod:  taskspb.HttpMethod_POST,
 					RelativeUri: "/cron/batch",
-					Body:        body,
+					Body:        body, // 100kb limit
 				},
 			},
 		},

--- a/cron/cron.go
+++ b/cron/cron.go
@@ -20,6 +20,7 @@ import (
 	"go.opencensus.io/plugin/ochttp"
 	taskspb "google.golang.org/genproto/googleapis/cloud/tasks/v2"
 
+	"github.com/bign8/chive-show/appengine"
 	"github.com/bign8/chive-show/models"
 	"github.com/bign8/chive-show/models/datastore"
 )
@@ -175,7 +176,7 @@ func (x *feedParser) enqueueBatch(ids []int) error {
 
 	// https://godoc.org/google.golang.org/genproto/googleapis/cloud/tasks/v2#AppEngineHttpRequest
 	_, err = x.tasker.CreateTask(x.context, &taskspb.CreateTaskRequest{
-		Parent: "projects/crucial-alpha-706/locations/us-central1/queues/default",
+		Parent: "projects/" + appengine.ProjectID() + "/locations/us-central1/queues/default",
 		Task: &taskspb.Task{
 			MessageType: &taskspb.Task_AppEngineHttpRequest{
 				AppEngineHttpRequest: &taskspb.AppEngineHttpRequest{

--- a/models/datastore/store.go
+++ b/models/datastore/store.go
@@ -21,7 +21,7 @@ import (
 func NewStore() (*Store, error) {
 	// https://cloud.google.com/docs/authentication/production
 	// GOOGLE_APPLICATION_CREDENTIALS=<path-to>/service-account.json
-	store, err := datastore.NewClient(context.Background(), appengine.AppID(context.TODO()))
+	store, err := datastore.NewClient(context.Background(), appengine.ProjectID())
 	if err != nil {
 		return nil, err
 	}

--- a/static/mobile.html
+++ b/static/mobile.html
@@ -90,7 +90,7 @@
     <div class="offcanvas offcanvas-bottom" tabindex="-1" id="tags">
       <div class="offcanvas-header">
         <h5 class="offcanvas-title">the<span style="color:#02fd00">C</span>hive Tags</h5>
-        <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        <a href="#" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></a>
       </div>
       <div class="offcanvas-body">
         <ul class="list-group list-group-flush">

--- a/static/mobile.html
+++ b/static/mobile.html
@@ -94,6 +94,7 @@
       </div>
       <div class="offcanvas-body">
         <ul class="list-group list-group-flush">
+          <!-- TODO: server side rendering of this list? -->
           <li class="list-group-item">
             Loading...
             <div class="spinner-border spinner-border-sm float-end" role="status"></div>
@@ -101,7 +102,7 @@
         </ul>
       </div>
     </div>
-    <div class="scroller"></div>
+    <div class="scroller"><!-- TODO: server side rendering of the first page of posts --></div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-gtEjrD/SeCtmISkJkNUaaKMoLD0//ElJ19smozuHV6z3Iehds+3Ulb9Bn9Plx0x4" crossorigin="anonymous"></script>
     <script src="mobile.js"></script>
   </body>

--- a/static/mobile.js
+++ b/static/mobile.js
@@ -54,8 +54,6 @@ function play_if_visible(e) {
 }
 
 function create_media(media) {
-    // TODO: lazy load media (initial load is pretty heavy)
-
     var img;
     if (media.url.endsWith(".mp4")) {
         let src = document.createElement('source')
@@ -68,11 +66,14 @@ function create_media(media) {
         img.playsInline = true
         img.append(src)
         img.onloadeddata = play_if_visible
+        img.preload = "metadata" // TODO: real lazy load; best we can do w/o custom logic on when to load content
         videos.observe(img) // have the scroll observer play if in viewport
     } else {
         img = document.createElement('img')
         img.src = media.url
         img.loading = "lazy"
+        img.height = 400 // HACK: force browser to treat unloaded images with a reasonable height so not everything is loaded at once. would be awesome if server provided image dimensions
+        img.onload = img.removeAttribute.bind(img, 'height')
     }
 
     if (media.title) {
@@ -137,6 +138,7 @@ function create_post(post) {
     mug.classList.add('rounded-circle')
     mug.alt = post.creator
     mug.title = post.creator
+    mug.loading = "lazy"
     banner.append(mug)
 
     let since = document.createElement('small')

--- a/static/mobile.js
+++ b/static/mobile.js
@@ -2,6 +2,26 @@ const BASE = '/api/v1/post?count=3'
 var next_link // state updated by pump and init
 let scroller = document.querySelector('.scroller')
 
+const colors = ['primary', 'secondary', 'success', 'warning', 'danger', 'info', 'dark']
+
+const signoffs = [
+    `<h4 class="alert-heading">That's everything!</h4><p class="mb-0">Go for a walk.</p>`,
+    `<h4 class="alert-heading">That's it!</h4><p class="mb-0">Better find a new hobby.</p>`,
+    `<h4 class="alert-heading">Welp...</h4><p class="mb-0">You found the end of the internet!</p>`,
+]
+
+function random(list) {
+    return list[Math.floor(Math.random() * list.length)]
+}
+
+function notify(msg, ...styles) {
+    // https://getbootstrap.com/docs/5.0/components/alerts/
+    let trailer = document.createElement('div')
+    trailer.classList.add('alert', 'text-center', ...styles)
+    trailer.innerHTML = msg
+    scroller.append(trailer)
+}
+
 // https://stackoverflow.com/a/3177838
 function timeSince(date) {
     var seconds = Math.floor((new Date() - date) / 1000);
@@ -79,8 +99,7 @@ function create_media(media) {
 function create_tag(tag) {
     // TODO: build user list of colored categories (and defaults)
     // TODO: create category equivalency map (ie: DAR = Daily Afternoon ...)
-    const colors = ['primary', 'secondary', 'success', 'warning', 'danger', 'info', 'dark']
-    let color = colors[Math.floor(Math.random() * colors.length)]
+    let color = random(colors)
 
     let badge = document.createElement('a')
     badge.href = '#' + tag
@@ -148,16 +167,17 @@ function create_post(post) {
 
 // load the next page of posts
 function pump() {
-    if (!next_link) {
-        alert("Thats everyting! Go for a walk!")
-        return
-    }
+    if (!next_link) return notify(random(signoffs), 'alert-warning')
     fetch(next_link).then(r => r.json()).then(res => {
         next_link = res.next_url
         return res.data
     }).then(posts => {
+        if (!posts) return notify(
+            `<h4 class="alert-header">Whoa</h4><p class="mb-0">We didn't find anything!<br/>Try <a href="#">Resetting filters</a></p>`,
+            'alert-danger', 'position-absolute', 'top-50', 'start-50', 'translate-middle'
+        )
         for (let post of posts) scroller.append(create_post(post))
-        bottom.observe(scroller.lastChild.previousSibling)
+        bottom.observe(scroller.lastChild.previousSibling ?? scroller.lastChild)
     })
 }
 

--- a/static/mobile.js
+++ b/static/mobile.js
@@ -44,6 +44,7 @@ function create_media(media) {
         img = document.createElement('video')
         img.loop = true
         img.muted = true // :shrug:
+        img.disableRemotePlayback = true // experimental (don't show "cast" button on mobile)
         img.playsInline = true
         img.append(src)
         img.onloadeddata = play_if_visible

--- a/static/mobile.js
+++ b/static/mobile.js
@@ -173,12 +173,14 @@ function pump() {
     if (!next_link) return notify(random(signoffs), 'alert-warning')
     fetch(next_link).then(r => r.json()).then(res => {
         next_link = res.next_url
-        return res.data
-    }).then(posts => {
-        if (!posts) return notify(
+        if (!res.self_url) return notify(
             `<h4 class="alert-header">Whoa</h4><p class="mb-0">We didn't find anything!<br/>Try <a href="#">Resetting filters</a></p>`,
             'alert-danger', 'position-absolute', 'top-50', 'start-50', 'translate-middle'
         )
+        if (!next_link && !res.data) return pump() // if we hit the end perfectly
+        return res.data
+    }).then(posts => {
+        if (!posts) return
         for (let post of posts) scroller.append(create_post(post))
         bottom.observe(scroller.lastChild.previousSibling ?? scroller.lastChild)
     })

--- a/static/mobile.js
+++ b/static/mobile.js
@@ -239,24 +239,25 @@ init()
 // Tag selector options (https://getbootstrap.com/docs/5.0/components/offcanvas/)
 let tags = document.getElementById('tags')
 let bs_tags = new bootstrap.Offcanvas(tags)
-tags.addEventListener('show.bs.offcanvas', e => {
+function init_offscreen() {
     fetch('/api/v1/tags').then(r => r.json()).then(data => {
         let list = document.querySelector('.list-group')
         list.innerHTML = ''
         for (const [tag, count] of Object.entries(data.tags)) {
-            let ele = document.createElement('div')
-            ele.classList.add('list-group-item')
+            let ele = document.createElement('a')
+            ele.classList.add('list-group-item', 'd-flex', 'justify-content-between', 'align-items-center')
             ele.innerText = tag
-            ele.addEventListener('click', e => { // WARNING: LEAKS!!!!
-                document.location = '#' + tag
-                bs_tags.hide()
-            })
+            ele.href = '#' + tag
+            ele.addEventListener('click', e => bs_tags.hide())
             list.append(ele)
 
             let span = document.createElement('span')
-            span.classList.add('badge', 'bg-primary', 'rounded-pill', 'float-end') // TODO: consistent coloring
+            span.classList.add('badge', 'bg-secondary', 'rounded-pill') // TODO: consistent coloring
+            span.style.width = '3em'
             span.innerText = count
             ele.append(span)
         }
+        tags.removeEventListener('show.bs.offcanvas', init_offscreen)
     })
-})
+}
+tags.addEventListener('show.bs.offcanvas', init_offscreen)

--- a/static/mobile.js
+++ b/static/mobile.js
@@ -72,6 +72,7 @@ function create_media(media) {
     } else {
         img = document.createElement('img')
         img.src = media.url
+        img.loading = "lazy"
     }
 
     if (media.title) {


### PR DESCRIPTION
Add some basic image deferred image loading to the infinite scroller to reduce client and server peak loads.  There is a hack in here where we assume images to be 400px tall until they are properly loaded.  This is not the best solution, but provides a way of providing an semi-accurate virtual scrollbar, as well as telling the browser that certain images are not in view.  The user may notice some jumpieness when while content is dynamically loading during scrolls, but it's fine for now.